### PR TITLE
Fix govet inline lint failure in mode validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.0
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0
-	golang.org/x/exp v0.0.0-20260209203927-2842357ff358
 	google.golang.org/grpc v1.79.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2W
 go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
-golang.org/x/exp v0.0.0-20260209203927-2842357ff358 h1:kpfSV7uLwKJbFSEgNhWzGSL47NDSF/5pYYQw1V0ub6c=
-golang.org/x/exp v0.0.0-20260209203927-2842357ff358/go.mod h1:R3t0oliuryB5eenPWl3rrQxwnNM3WTwnsRZZiXLAAW8=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=

--- a/init.go
+++ b/init.go
@@ -23,7 +23,6 @@ import (
 	"time"
 	"unicode"
 
-	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -118,8 +117,16 @@ func init() {
 		os.Exit(StatusInvalidArguments)
 	}
 
-	if !slices.Contains(getSupportedModes(), flMode)  {
-		argError("Unsupported -mode. Please use one of %v", getSupportedModes())
+	supportedModes := getSupportedModes()
+	modeSupported := false
+	for _, mode := range supportedModes {
+		if mode == flMode {
+			modeSupported = true
+			break
+		}
+	}
+	if !modeSupported {
+		argError("Unsupported -mode. Please use one of %v", supportedModes)
 	}
 	if flConnTimeout <= 0 {
 		argError("-connect-timeout must be greater than zero (specified: %v)", flConnTimeout)


### PR DESCRIPTION
## Summary
- Replace `golang.org/x/exp/slices.Contains` with a plain loop in `init.go`
- Remove unused `golang.org/x/exp` dependency
- Fixes CI `golangci-lint` failure: `inline: cannot inline: type parameter inference is not yet supported (govet)`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI `golangci-lint` passes on PR

Made with [Cursor](https://cursor.com)